### PR TITLE
Fixes bugs related to pagination on search and row count

### DIFF
--- a/src/Livewire/Table.php
+++ b/src/Livewire/Table.php
@@ -236,6 +236,7 @@ class Table extends Component
     public function changeNumberOfRowsPerPage(int $numberOfRowsPerPage): void
     {
         $this->numberOfRowsPerPage = $numberOfRowsPerPage;
+        $this->resetPage();
     }
 
     public function sortBy(string $columnKey): void
@@ -376,5 +377,11 @@ class Table extends Component
         }
         $this->configParams = [...$this->configParams, ...$configParams];
         $this->emitSelf('$refresh');
+    }
+    
+    public function updating ($name, $value) {
+        if ($name === 'searchBy') {
+            $this->resetPage();
+        }
     }
 }


### PR DESCRIPTION
When searching after you've already paginated, if the results of the search provide fewer results than would exist in the current pagination, it would show zero records. The same is true for changing the number of rows to display after pagination. These two line changes force a page refresh whenever a search or row count is updated, ensuring we go back to page 1 of pagination